### PR TITLE
Strongly-type the "s-expression" module

### DIFF
--- a/src/L1/L1-ast.ts
+++ b/src/L1/L1-ast.ts
@@ -79,7 +79,7 @@ const parseL1Atomic = (sexp: string): CExp =>
 const isPrimitiveOp = (x: string): boolean =>
     ["+", "-", "*", "/", ">", "<", "=", "not"].includes(x)
 
-const parseL1CExp = (sexp: any): CExp | Error =>
+const parseL1CExp = (sexp: StringTree): CExp | Error =>
     isArray(sexp) ? makeAppExp(parseL1CExp(first(sexp)),
                                map(parseL1CExp, rest(sexp))) :
     isString(sexp) ? parseL1Atomic(sexp) :

--- a/src/L1/L1-eval.ts
+++ b/src/L1/L1-eval.ts
@@ -1,6 +1,5 @@
 // L1-eval.ts
 
-import { strict as assert } from 'assert';
 import { filter, map, reduce } from "ramda";
 import { first, isEmpty, rest } from "../shared/list";
 import { CExp, DefineExp, Exp, PrimOp, Program } from "./L1-ast";

--- a/src/L3/L3-ast.ts
+++ b/src/L3/L3-ast.ts
@@ -4,7 +4,7 @@
 import { map, zipWith } from "ramda";
 import { makeEmptySExp, makeSymbolSExp, SExp, makeCompoundSExp, valueToString } from './L3-value'
 import { first, second, rest, allT, isArray, isString, isEmpty, isSexpString, isNumericString } from "../shared/list";
-import p, { StringTree } from "s-expression";
+import p, { StringTree, SexpString } from "s-expression";
 import {hasNoError, safeF, safeFL, safeF2, getErrorMessages} from '../shared/error'
 
 /*
@@ -162,7 +162,7 @@ const parseProgram = (es: Array<Parsed | Error>): Program | Error =>
     hasNoError(es) ? Error(`Program cannot be embedded in another program - ${es}`) :
     Error(getErrorMessages(es));
 
-const parseL3Atomic = (sexp: string | String): CExp =>
+const parseL3Atomic = (sexp: string | SexpString): CExp =>
     sexp === "#t" ? makeBoolExp(true) :
     sexp === "#f" ? makeBoolExp(false) :
     isString(sexp) && isNumericString(sexp) ? makeNumExp(+sexp) :

--- a/src/L3/lexicalAddress.ts
+++ b/src/L3/lexicalAddress.ts
@@ -100,7 +100,7 @@ Examples:
 parseLA("1") -> '(num-exp 1)
 parseLA("(if #t (+ 1 2) 'ok)") -> '(IfExpLA (BoolExp true) (AppExpLA (VarRef +) ((num-exp 1) (num-exp 2))) (literal-exp ok))
 */
-import parseSexp, { StringTree } from "s-expression";
+import parseSexp, { StringTree, SexpString } from "s-expression";
 
 export const parseLA = (x: string): CExpLA | Error =>
     parseLASExp(parseSexp(x));
@@ -112,7 +112,7 @@ export const parseLASExp = (sexp: StringTree): CExpLA | Error =>
     isSexpString(sexp) ? parseLAAtomic(sexp) :
     Error(`Parse: Unexpected type ${sexp}`);
 
-const parseLAAtomic = (sexp: string | String): CExpLA =>
+const parseLAAtomic = (sexp: string | SexpString): CExpLA =>
     sexp === "#t" ? makeBoolExp(true) :
     sexp === "#f" ? makeBoolExp(false) :
     isString(sexp) && isNumericString(sexp) ? makeNumExp(+sexp) :

--- a/src/L3/lexicalAddress.ts
+++ b/src/L3/lexicalAddress.ts
@@ -22,7 +22,7 @@ import { concat, map } from 'ramda';
 import { BoolExp, LitExp, NumExp, StrExp, VarDecl, VarRef } from './L3-ast';
 import { isBoolExp, isLitExp, isNumExp, isStrExp, isVarRef } from './L3-ast';
 import { makeBoolExp, makeNumExp, makeStrExp, makeVarDecl, makeVarRef } from './L3-ast';
-import { isArray, isEmpty, isNumericString, isSexpString, isString } from '../shared/list';
+import { isArray, isEmpty, isNumericString, isSexpString, isString, allT } from '../shared/list';
 import { parseLitExp } from './L3-ast';
 import { isError, safeFL } from '../shared/error';
 import { first, rest} from '../shared/list';
@@ -100,41 +100,45 @@ Examples:
 parseLA("1") -> '(num-exp 1)
 parseLA("(if #t (+ 1 2) 'ok)") -> '(IfExpLA (BoolExp true) (AppExpLA (VarRef +) ((num-exp 1) (num-exp 2))) (literal-exp ok))
 */
-// @ts-ignore
-import parseSexp from "s-expression";
+import parseSexp, { StringTree } from "s-expression";
 
 export const parseLA = (x: string): CExpLA | Error =>
     parseLASExp(parseSexp(x));
 
-export const parseLASExp = (sexp: any): CExpLA | Error =>
+export const parseLASExp = (sexp: StringTree): CExpLA | Error =>
     isEmpty(sexp) ? Error("Parse: Unexpected empty") :
     isArray(sexp) ? parseLACompound(sexp) :
     isString(sexp) ? parseLAAtomic(sexp) :
     isSexpString(sexp) ? parseLAAtomic(sexp) :
     Error(`Parse: Unexpected type ${sexp}`);
 
-const parseLAAtomic = (sexp: string): CExpLA =>
+const parseLAAtomic = (sexp: string | String): CExpLA =>
     sexp === "#t" ? makeBoolExp(true) :
     sexp === "#f" ? makeBoolExp(false) :
-    isNumericString(sexp) ? makeNumExp(+sexp) :
+    isString(sexp) && isNumericString(sexp) ? makeNumExp(+sexp) :
     isSexpString(sexp) ? makeStrExp(sexp.toString()) :
     makeVarRef(sexp);
 
-const parseLACompound = (sexps: any[]): CExpLA | Error =>
+const parseLACompound = (sexps: StringTree[]): CExpLA | Error =>
     first(sexps) === "if" ? parseIfExpLA(sexps) :
     first(sexps) === "lambda" ? parseProcExpLA(sexps) :
     first(sexps) === "quote" ? parseLitExp(sexps) :
     parseAppExpLA(sexps);
 
-const parseAppExpLA = (sexps: any[]): AppExpLA | Error =>
+const parseAppExpLA = (sexps: StringTree[]): AppExpLA | Error =>
     safeFL((cexps: CExpLA[]) => makeAppExpLA(first(cexps), rest(cexps)))(map(parseLASExp, sexps));
 
-const parseIfExpLA = (sexps: any[]): IfExpLA | Error =>
+const parseIfExpLA = (sexps: StringTree[]): IfExpLA | Error =>
     safeFL((cexps: CExpLA[]) => makeIfExpLA(cexps[0], cexps[1], cexps[2]))(map(parseLASExp, rest(sexps)));
 
-const parseProcExpLA = (sexps: any[]): ProcExpLA | Error =>
-    safeFL((body: CExpLA[]) => makeProcExpLA( map(makeVarDecl, sexps[1]), body))
-        (map(parseLASExp, rest(rest(sexps))));
+const parseProcExpLA = (sexps: StringTree[]): ProcExpLA | Error => {
+    const vars = sexps[1];
+    if (isArray(vars) && allT(isString, vars)) {
+        return safeFL((body: CExpLA[]) => makeProcExpLA(map(makeVarDecl, vars), body))(map(parseLASExp, rest(rest(sexps))));
+    } else {
+        return Error("Invalid vars for ProcExp");
+    }
+}
 
 // ========================================================
 // Unparse

--- a/src/L4/L4-ast.ts
+++ b/src/L4/L4-ast.ts
@@ -2,7 +2,7 @@
 // ===========================================================
 // AST type models
 import { map, zipWith } from "ramda";
-import p, { StringTree } from "s-expression";
+import p, { StringTree, SexpString } from "s-expression";
 import { allT, first, second, rest, isArray, isEmpty, isSexpString, isString, isNumericString } from "../shared/list";
 import {isError, hasNoError, safeF, safeFL, safeF2, getErrorMessages} from '../shared/error'
 import { isSymbolSExp, isEmptySExp, isCompoundSExp } from './L4-value';
@@ -185,7 +185,7 @@ const parseProgram = (es: Array<Parsed | Error>): Program | Error =>
     hasNoError(es) ? Error(`Program cannot be embedded in another program - ${es}`) :
     Error(getErrorMessages(es));
 
-export const parseAtomic = (sexp: string | String): CExp =>
+export const parseAtomic = (sexp: string | SexpString): CExp =>
     sexp === "#t" ? makeBoolExp(true) :
     sexp === "#f" ? makeBoolExp(false) :
     isString(sexp) && isNumericString(sexp) ? makeNumExp(+sexp) :

--- a/src/L5/L5-ast.ts
+++ b/src/L5/L5-ast.ts
@@ -1,11 +1,12 @@
+/// <reference path="../shared/s-expression.d.ts" />
+
 // ===========================================================
 // AST type models for L5
 // L5 extends L4 with:
 // optional type annotations
 
 import { join, map, zipWith } from "ramda";
-// @ts-ignore
-import p from 's-expression';
+import p, { StringTree } from 's-expression';
 import { isCompoundSExp, isEmptySExp, isSymbolSExp, makeCompoundSExp, makeEmptySExp, makeSymbolSExp, SExp, valueToString } from './L5-value';
 import { isTVar, makeFreshTVar, parseTExp, unparseTExp, TExp } from './TExp';
 import { getErrorMessages, hasNoError, isError, safeF, safeFL, safeF2 } from '../shared/error';
@@ -156,8 +157,8 @@ export const isSetExp = (x: any): x is SetExp => x.tag === "SetExp";
 // ========================================================
 // Parsing utilities
 
-export const isEmpty = (x: any): boolean => x.length === 0;
-export const isArray = (x: any): boolean => x instanceof Array;
+export const isEmpty = <T>(x: T[]): boolean => x.length === 0;
+export const isArray = Array.isArray;
 export const isString = (x: any): x is string => typeof x === "string";
 export const isNumber = (x: any): x is number => typeof x === "number";
 export const isBoolean = (x: any): x is boolean => typeof x === "boolean";
@@ -177,20 +178,20 @@ export const isNumericString = (x: string): boolean => JSON.stringify(+x) === x;
 export const parse = (x: string): Parsed | Error =>
     parseSexp(p(x));
 
-export const parseSexp = (sexp: any): Parsed | Error =>
-    isEmpty(sexp) ? Error("Parse: Unexpected empty") :
+export const parseSexp = (sexp: StringTree): Parsed | Error =>
+    isArray(sexp) && isEmpty(sexp) ? Error("Parse: Unexpected empty") :
     isArray(sexp) ? parseCompound(sexp) :
     isString(sexp) ? parseAtomic(sexp) :
     isSexpString(sexp) ? parseAtomic(sexp) :
     Error(`Parse: Unexpected type ${sexp}`);
 
-export const parseAtomic = (sexp: string): AtomicExp =>
+export const parseAtomic = (sexp: string | String): AtomicExp =>
     sexp === "#t" ? makeBoolExp(true) :
     sexp === "#f" ? makeBoolExp(false) :
-    isNumericString(sexp) ? makeNumExp(+sexp) :
+    isString(sexp) && isNumericString(sexp) ? makeNumExp(+sexp) :
     isSexpString(sexp) ? makeStrExp(sexp.toString()) :
-    isPrimitiveOp(sexp) ? makePrimOp(sexp) :
-    makeVarRef(sexp);
+    isString(sexp) && isPrimitiveOp(sexp) ? makePrimOp(sexp) :
+    makeVarRef(sexp.toString());
 
 /*
     // <prim-op>  ::= + | - | * | / | < | > | = | not |  eq? | string=?
@@ -198,28 +199,11 @@ export const parseAtomic = (sexp: string): AtomicExp =>
     //                  | boolean? | symbol? | string?
 */
 const isPrimitiveOp = (x: string): boolean =>
-    x === "+" ||
-    x === "-" ||
-    x === "*" ||
-    x === "/" ||
-    x === ">" ||
-    x === "<" ||
-    x === "=" ||
-    x === "not" ||
-    x === "eq?" ||
-    x === "string=?" ||
-    x === "cons" ||
-    x === "car" ||
-    x === "cdr" ||
-    x === "list?" ||
-    x === "number?" ||
-    x === "boolean?" ||
-    x === "symbol?" ||
-    x === "string?" ||
-    x === "display" ||
-    x === "newline";
+    ["+", "-", "*", "/", ">", "<", "=", "not", "eq?",
+     "string=?", "cons", "car", "cdr", "pair?", "list?",
+     "number?", "boolean?", "symbol?", "string?", "display", "newline"].includes(x);
 
-const parseCompound = (sexps: any[]): Parsed | Error =>
+const parseCompound = (sexps: StringTree[]): Parsed | Error =>
     isEmpty(sexps) ? Error("Unexpected empty sexp") :
     (first(sexps) === "L5") ? parseProgram(map(parseSexp, rest(sexps))) :
     (first(sexps) === "define") ? parseDefine(rest(sexps)) :
@@ -236,18 +220,18 @@ const safeMakeDefineExp = (vd: VarDecl | Error, val: CExp | Error): DefineExp | 
     isError(val) ? val :
     makeDefineExp(vd, val);
 
-const parseDefine = (es: any[]): DefineExp | Error =>
+const parseDefine = (es: StringTree[]): DefineExp | Error =>
     (es.length !== 2) ? Error(`define should be (define var val) - ${es}`) :
     !isConcreteVarDecl(es[0]) ? Error(`Expected (define <VarDecl> <CExp>) - ${es[0]}`) :
     safeMakeDefineExp(parseVarDecl(es[0]), parseCExp(es[1]));
 
-export const parseCExp = (sexp: any): CExp | Error =>
+export const parseCExp = (sexp: StringTree): CExp | Error =>
     isArray(sexp) ? parseCompoundCExp(sexp) :
     isString(sexp) ? parseAtomic(sexp) :
     isSexpString(sexp) ? parseAtomic(sexp) :
     Error("Unexpected type" + sexp);
 
-const parseCompoundCExp = (sexps: any[]): CExp | Error =>
+const parseCompoundCExp = (sexps: StringTree[]): CExp | Error =>
     isEmpty(sexps) ? Error("Unexpected empty") :
     first(sexps) === "if" ? parseIfExp(sexps) :
     first(sexps) === "lambda" ? parseProcExp(sexps) :
@@ -257,39 +241,48 @@ const parseCompoundCExp = (sexps: any[]): CExp | Error =>
     first(sexps) === "quote" ? parseLitExp(sexps) :
     parseAppExp(sexps)
 
-const parseAppExp = (sexps: any[]): AppExp | Error =>
+const parseAppExp = (sexps: StringTree[]): AppExp | Error =>
     safeFL((cexps: CExp[]) => makeAppExp(first(cexps), rest(cexps)))(map(parseCExp, sexps));
 
-const parseIfExp = (sexps: any[]): IfExp | Error =>
+const parseIfExp = (sexps: StringTree[]): IfExp | Error =>
     safeFL((cexps: CExp[]) => makeIfExp(cexps[0], cexps[1], cexps[2]))(map(parseCExp, rest(sexps)));
 
 // (lambda (<vardecl>*) [: returnTE]? <CExp>+)
-const parseProcExp = (sexps: any[]): ProcExp | Error => {
-    const args: Array<VarDecl | Error> = map(parseVarDecl, sexps[1]);
-    const returnTE = (sexps[2] === ":") ? parseTExp(sexps[3]) : makeFreshTVar();
-    const body : (CExp | Error)[] = map(parseCExp, (sexps[2] === ":") ? sexps.slice(4) : sexps.slice(2));
-    if (! hasNoError(args))
-        return Error(getErrorMessages(args));
-    else if (! hasNoError(body))
-        return Error(getErrorMessages(body));
-    else if (isError(returnTE))
-        return Error(`Bad return type: ${returnTE}`);
-    else
-        return makeProcExp(args, body, returnTE);
+const parseProcExp = (sexps: StringTree[]): ProcExp | Error => {
+    if (isArray(sexps[1])){
+        const args: Array<VarDecl | Error> = map(parseVarDecl, sexps[1]);
+        const returnTE = (sexps[2] === ":") ? parseTExp(sexps[3]) : makeFreshTVar();
+        const body : (CExp | Error)[] = map(parseCExp, (sexps[2] === ":") ? sexps.slice(4) : sexps.slice(2));
+        if (! hasNoError(args))
+            return Error(getErrorMessages(args));
+        else if (! hasNoError(body))
+            return Error(getErrorMessages(body));
+        else if (isError(returnTE))
+            return Error(`Bad return type: ${returnTE}`);
+        else
+            return makeProcExp(args, body, returnTE);
+    } else {
+        return Error(`Invalid args ${JSON.stringify(sexps[1])}`);
+    }
 }
 
 // LetExp ::= (let (<binding>*) <cexp>+)
-const parseLetExp = (sexps: any[]): LetExp | Error =>
-    sexps.length < 3 ? Error(`Expected (let (<binding>*) <cexp>+) - ${sexps}`) :
-    safeMakeLetExp(parseBindings(sexps[1]),
-                   map(parseCExp, sexps.slice(2)));
+const parseLetExp = (sexps: StringTree[]): LetExp | Error => {
+    if (sexps.length < 3) {
+        return Error(`Expected (let (<binding>*) <cexp>+) - ${sexps}`);
+    } else {
+        const bdgs = sexps[1];
+        return isArray(bdgs) ? safeMakeLetExp(parseBindings(bdgs), map(parseCExp, sexps.slice(2)))
+                             : Error(`Invalid bindings ${bdgs}`);
+    }
+}
 
 const safeMakeLetExp = (bindings: Binding[] | Error, body: Array<CExp | Error>): LetExp | Error =>
     isError(bindings) ? bindings :
     hasNoError(body) ? makeLetExp(bindings, body) :
     Error(getErrorMessages(body));
 
-const isConcreteVarDecl = (sexp:  any): boolean =>
+const isConcreteVarDecl = (sexp:  StringTree): boolean =>
     isString(sexp) ||
     (isArray(sexp) && sexp.length > 2 && isString(sexp[0]) && (sexp[1] === ':'));
 
@@ -297,16 +290,25 @@ const safeMakeVarDecl = (v: string, te: TExp | Error): VarDecl | Error =>
     isError(te) ? te :
     makeVarDecl(v, te);
 
-export const parseVarDecl = (x: any): VarDecl | Error =>
-    isString(x) ? makeVarDecl(x, makeFreshTVar()) :
-    safeMakeVarDecl(x[0], parseTExp(x[2]));
+export const parseVarDecl = (x: StringTree): VarDecl | Error => {
+    if (isString(x)) {
+        return makeVarDecl(x, makeFreshTVar())
+    } else {
+        const v = x[0];
+        return isString(v) ? safeMakeVarDecl(v, parseTExp(x[2])) : Error(`Invalid var ${v}`);
+    }
+}
 
-export const parseDecls = (sexps: any[]): Array<VarDecl | Error> =>
+export const parseDecls = (sexps: StringTree[]): Array<VarDecl | Error> =>
     map(parseVarDecl, sexps);
 
-const parseBindings = (pairs: any[]): Binding[] | Error =>
-    safeMakeBindings(parseDecls(map(first, pairs)),
-                     map(parseCExp, map(second, pairs)));
+const parseBindings = (pairs: StringTree[]): Binding[] | Error => {
+    if (allT(isArray, pairs)) {
+        return safeMakeBindings(parseDecls(map(first, pairs)), map(parseCExp, map(second, pairs)));
+    } else {
+        return Error(`Invalid bindings ${JSON.stringify(pairs)}`);
+    }
+}
 
 const safeMakeBindings = (decls: Array<VarDecl | Error>, vals: Array<CExp | Error>): Binding[] | Error =>
     (hasNoError(vals) && hasNoError(decls)) ? zipWith(makeBinding, decls, vals) :
@@ -314,41 +316,52 @@ const safeMakeBindings = (decls: Array<VarDecl | Error>, vals: Array<CExp | Erro
     Error(getErrorMessages(decls));
 
 // LetrecExp ::= (letrec (<binding>*) <cexp>+)
-const parseLetrecExp = (sexps: any[]): LetrecExp | Error =>
-    sexps.length < 3 ? Error(`Expected (letrec (<binding>*) <cexp>+) - ${sexps}`) :
-    safeMakeLetrecExp(parseBindings(sexps[1]),
-                      map(parseCExp, sexps.slice(2)));
+const parseLetrecExp = (sexps: StringTree[]): LetrecExp | Error => {
+    if (sexps.length < 3) {
+        return Error(`Expected (letrec (<binding>*) <cexp>+) - ${sexps}`);
+    } else {
+        const bdgs = sexps[1];
+        return isArray(bdgs) ? safeMakeLetrecExp(parseBindings(bdgs), map(parseCExp, sexps.slice(2)))
+                             : Error(`Invalid bindings ${bdgs}`);
+    }
+}
 
 const safeMakeLetrecExp = (bindings: Binding[] | Error, body: Array<CExp | Error>): LetrecExp | Error =>
     isError(bindings) ? bindings :
     hasNoError(body) ? makeLetrecExp(bindings, body) :
     Error(getErrorMessages(body));
 
-const parseSetExp = (es: any[]): SetExp | Error =>
-    (es.length !== 3) ? Error(`set! should be (set! var val) - ${es}`) :
-    !isString(es[1]) ? Error(`Expected (set! <var> <CExp>) - ${es[1]}`) :
-    safeF((val: CExp) => makeSetExp(makeVarRef(es[1]), val))(parseCExp(es[2]));
+const parseSetExp = (es: StringTree[]): SetExp | Error => {
+    if (es.length !== 3) {
+        return Error(`set! should be (set! var val) - ${es}`);
+    } else if (!isString(es[1])) {
+        return Error(`Expected (set! <var> <CExp>) - ${es[1]}`);
+    } else {
+        const v = es[1];
+        return safeF((val: CExp) => makeSetExp(makeVarRef(v), val))(parseCExp(es[2]));
+    }
+}
 
 // sexps has the shape (quote <sexp>)
-export const parseLitExp = (sexps: any[]): LitExp | Error =>
+export const parseLitExp = (sexps: StringTree[]): LitExp | Error =>
     safeF(makeLitExp)(parseSExp(second(sexps)));
 
-export const isDottedPair = (sexps: any[]): boolean =>
+export const isDottedPair = (sexps: StringTree[]): boolean =>
     sexps.length === 3 && 
     sexps[1] === "."
 
-export const makeDottedPair = (sexps : any[]): SExp | Error =>
+export const makeDottedPair = (sexps : StringTree[]): SExp | Error =>
     safeF2(makeCompoundSExp)(parseSExp(sexps[0]), parseSExp(sexps[2]))
 
 // x is the output of p (sexp parser)
-export const parseSExp = (x: any): SExp | Error =>
+export const parseSExp = (x: StringTree): SExp | Error =>
     x === "#t" ? true :
     x === "#f" ? false :
-    isNumericString(x) ? +x :
+    isString(x) && isNumericString(x) ? +x :
     isSexpString(x) ? x.toString() :
     isString(x) ? makeSymbolSExp(x) :
     x.length === 0 ? makeEmptySExp() :
-    isDottedPair(x) ? makeDottedPair(x) :
+    isArray(x) && isDottedPair(x) ? makeDottedPair(x) :
     isArray(x) ? (
         // fail on (x . y z)
         x[0] === '.' ? Error("Bad dotted sexp: " + x) : 

--- a/src/L5/L5-ast.ts
+++ b/src/L5/L5-ast.ts
@@ -6,7 +6,7 @@
 // optional type annotations
 
 import { join, map, zipWith } from "ramda";
-import p, { StringTree } from 's-expression';
+import p, { StringTree, SexpString } from 's-expression';
 import { isCompoundSExp, isEmptySExp, isSymbolSExp, makeCompoundSExp, makeEmptySExp, makeSymbolSExp, SExp, valueToString } from './L5-value';
 import { isTVar, makeFreshTVar, parseTExp, unparseTExp, TExp } from './TExp';
 import { getErrorMessages, hasNoError, isError, safeF, safeFL, safeF2 } from '../shared/error';
@@ -185,7 +185,7 @@ export const parseSexp = (sexp: StringTree): Parsed | Error =>
     isSexpString(sexp) ? parseAtomic(sexp) :
     Error(`Parse: Unexpected type ${sexp}`);
 
-export const parseAtomic = (sexp: string | String): AtomicExp =>
+export const parseAtomic = (sexp: string | SexpString): AtomicExp =>
     sexp === "#t" ? makeBoolExp(true) :
     sexp === "#f" ? makeBoolExp(false) :
     isString(sexp) && isNumericString(sexp) ? makeNumExp(+sexp) :

--- a/src/L5/TExp.ts
+++ b/src/L5/TExp.ts
@@ -30,8 +30,7 @@
 ;; [Empty -> void]
 */
 import { chain, concat, filter, map, uniq } from "ramda";
-// @ts-ignore
-import p = require("s-expression");
+import p, { StringTree } from "s-expression";
 import { isArray, isBoolean, isEmpty, isString } from './L5-ast';
 import { makeBox, setBox, unbox, Box } from '../shared/box';
 import { getErrorMessages, hasNoError, isError, safeF, safeFL } from '../shared/error';
@@ -147,7 +146,7 @@ export const parseTE = (t: string): TExp | Error =>
 ;; parseTExp('(T * T -> boolean)') => '(proc-te ((tvar T) (tvar T)) bool-te)
 ;; parseTExp('(number -> (number -> number)') => '(proc-te (num-te) (proc-te (num-te) num-te))
 */
-export const parseTExp = (texp: any): TExp | Error =>
+export const parseTExp = (texp: StringTree): TExp | Error =>
     (texp === "number") ? makeNumTExp() :
     (texp === "boolean") ? makeBoolTExp() :
     (texp === "void") ? makeVoidTExp() :

--- a/src/shared/list.ts
+++ b/src/shared/list.ts
@@ -1,6 +1,7 @@
 // List operations similar to car/cdr/cadr in Scheme
 
 import { all } from 'ramda';
+import { SexpString } from 's-expression';
 
 export const first = <T>(x: T[]): T => x[0];
 export const second = <T>(x: T[]): T => x[1];
@@ -22,7 +23,7 @@ export const isBoolean = (x: any): x is boolean => typeof x === "boolean";
 // to distinguish them from symbols - which are encoded as 'a'
 // These are constructed using the new String("a") constructor
 // and can be distinguished from regular strings based on the constructor.
-export const isSexpString = (x: any): x is String =>
+export const isSexpString = (x: any): x is SexpString =>
     ! isString(x) && x.constructor && x.constructor.name === "String";
 // A weird method to check that a string is a string encoding of a number
 export const isNumericString = (x: string): boolean => JSON.stringify(+x) === x;

--- a/src/shared/list.ts
+++ b/src/shared/list.ts
@@ -22,7 +22,7 @@ export const isBoolean = (x: any): x is boolean => typeof x === "boolean";
 // to distinguish them from symbols - which are encoded as 'a'
 // These are constructed using the new String("a") constructor
 // and can be distinguished from regular strings based on the constructor.
-export const isSexpString = (x: any): boolean =>
+export const isSexpString = (x: any): x is String =>
     ! isString(x) && x.constructor && x.constructor.name === "String";
 // A weird method to check that a string is a string encoding of a number
 export const isNumericString = (x: string): boolean => JSON.stringify(+x) === x;

--- a/src/shared/s-expression.d.ts
+++ b/src/shared/s-expression.d.ts
@@ -1,4 +1,4 @@
 declare module 's-expression' {
-    export type StringArray = string | Array<StringArray>;
-    export default function SParse(stream: string): StringArray;
+    export type StringTree = string | String | StringTree[];
+    export default function parse(x: string): StringTree;
 }

--- a/src/shared/s-expression.d.ts
+++ b/src/shared/s-expression.d.ts
@@ -1,5 +1,14 @@
 declare module 's-expression' {
     export type SexpString = String;
     export type StringTree = string | SexpString | StringTree[];
+
+    /*
+        The types returned by the parser are:
+        string - for any token which is not a string,
+                 according to the tokenization rules of S-expressions.
+        SexpString - for tokens of the form "..."
+        StringTree[] - for S-expressions that contain sub-expressions
+                       (of the form "(<expr1> ... <exprn>)")
+    */
     export default function parse(x: string): StringTree;
 }

--- a/src/shared/s-expression.d.ts
+++ b/src/shared/s-expression.d.ts
@@ -1,4 +1,5 @@
 declare module 's-expression' {
-    export type StringTree = string | String | StringTree[];
+    export type SexpString = String;
+    export type StringTree = string | SexpString | StringTree[];
     export default function parse(x: string): StringTree;
 }


### PR DESCRIPTION
The function exported from the `s-expression` package now returns a type of `StringTree`, the details of which are in `src/shared/s-expression.d.ts`.